### PR TITLE
feat: 検索結果更新時に自動的にトップへスクロール

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -96,6 +96,21 @@ watch(isInitialized, (initialized) => {
   }
 });
 
+// Scroll to top when search results change (but not when loading more)
+watch([images, totalHits], ([newImages, newTotal], [oldImages, oldTotal]) => {
+  // Check if this is a new search (first image changed or total count changed)
+  const newFirstId = newImages[0]?.id ?? null;
+  const oldFirstId = oldImages?.[0]?.id ?? null;
+
+  // Scroll to top if:
+  // - There are new images AND
+  // - Either the first image ID changed OR the total count changed
+  //   (meaning it's a new search, not loadMore)
+  if (newFirstId !== null && (newFirstId !== oldFirstId || newTotal !== oldTotal)) {
+    window.scrollTo(0, 0);
+  }
+});
+
 onMounted(() => {
   window.addEventListener("scroll", handleScroll);
 });


### PR DESCRIPTION
検索クエリが変更されて新しい検索結果が表示される際、
自動的にページトップにスクロールするようにしました。
無限スクロールでの追加読み込み時はスクロール位置を維持します。

- 検索結果の最初の画像IDを監視
- IDが変更された場合のみトップにスクロール
- loadMore()での追加読み込みではスクロールしない