### PR TITLE
fix: トップページの初回ロード時に検索が2回実行される問題を修正

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -48,6 +48,7 @@ const infoModalVisible = ref(false);
 const selectedImageForInfo = ref<SearchHit | null>(null);
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let isFirstSearch = ref(true);
 
 /**
  * Check if query ends with an incomplete prefix pattern
@@ -84,16 +85,15 @@ watch([searchQuery, searchMode], ([newQuery, newMode]) => {
     return;
   }
 
+  // Skip debounce for the first search (initial page load)
+  const delay = isFirstSearch.value ? 0 : 300;
+  if (isFirstSearch.value) {
+    isFirstSearch.value = false;
+  }
+
   debounceTimer = setTimeout(() => {
     search(newQuery, newMode);
-  }, 300);
-});
-
-// Initial search when params are ready
-watch(isInitialized, (initialized) => {
-  if (initialized) {
-    search(searchQuery.value, searchMode.value);
-  }
+  }, delay);
 });
 
 onMounted(() => {


### PR DESCRIPTION
初回ロード時に以下の問題が発生していた：
1. isInitialized の watch で即座に検索実行
2. 同時に [searchQuery, searchMode] の watch も発火し、300ms後に再度検索実行

修正内容：
- isInitialized の watch を削除
- [searchQuery, searchMode] の watch で初回検索かどうかを判定
- 初回検索は即座に実行、その後の検索のみ 300ms の debounce を適用