### PR TITLE
複数バックエンドURL設定・切り替え機能を追加

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import express from "express";
-import cors from "cors";
+import cors, { CorsOptions } from "cors";
 import { searchRouter } from "./routes/search.js";
 import { imagesRouter } from "./routes/images.js";
 import { tagsRouter } from "./routes/tags.js";
@@ -10,7 +10,35 @@ import { tagCache } from "./services/tagCache.js";
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(cors());
+// CORS configuration
+function getCorsOptions(): CorsOptions {
+  const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+  // If not set or empty, allow all origins (default behavior)
+  if (!allowedOrigins || allowedOrigins.trim() === "") {
+    return {};
+  }
+
+  // Parse comma-separated origins
+  const origins = allowedOrigins
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  return {
+    origin: (origin, callback) => {
+      // Allow requests with no origin (same-origin, curl, etc.)
+      if (!origin || origins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  };
+}
+
+app.use(cors(getCorsOptions()));
 app.use(express.json());
 
 // Routes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
       - S3_PUBLIC_ENDPOINT
       - S3_BUCKET
       - PORT=3000
+      - CORS_ALLOWED_ORIGINS
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/components/BackendSelector.vue
+++ b/frontend/src/components/BackendSelector.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue'
+import Select from 'primevue/select'
+import { useBackendSettings } from '../composables/useBackendSettings'
+
+const emit = defineEmits<{
+  change: [backendId: string]
+}>()
+
+const {
+  sortedBackends,
+  selectedId,
+  isInitialized,
+  loadBackends,
+  selectBackend,
+} = useBackendSettings()
+
+const showSelector = computed(() => sortedBackends.value.length > 1)
+
+const selectedValue = computed({
+  get: () => selectedId.value,
+  set: (value) => {
+    if (value && value !== selectedId.value) {
+      selectBackend(value)
+      emit('change', value)
+    }
+  }
+})
+
+onMounted(() => {
+  loadBackends()
+})
+
+// Re-emit change when selectedId changes externally (e.g., from settings)
+watch(selectedId, (newId, oldId) => {
+  if (newId && oldId && newId !== oldId) {
+    emit('change', newId)
+  }
+})
+</script>
+
+<template>
+  <Select
+    v-if="showSelector && isInitialized"
+    v-model="selectedValue"
+    :options="sortedBackends"
+    option-label="name"
+    option-value="id"
+    placeholder="Backend"
+    class="backend-selector"
+  />
+</template>
+
+<style scoped>
+.backend-selector {
+  min-width: 120px;
+  max-width: 180px;
+}
+
+.backend-selector :deep(.p-select-label) {
+  padding: 0.5rem 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .backend-selector {
+    min-width: 100px;
+    max-width: 140px;
+  }
+
+  .backend-selector :deep(.p-select-label) {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.875rem;
+  }
+}
+</style>

--- a/frontend/src/components/BackendSettings.vue
+++ b/frontend/src/components/BackendSettings.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import Button from 'primevue/button'
+import Dialog from 'primevue/dialog'
+import InputText from 'primevue/inputtext'
+import Message from 'primevue/message'
+import Tag from 'primevue/tag'
+import { useToast } from 'primevue/usetoast'
+import { useBackendSettings } from '../composables/useBackendSettings'
+import type { BackendConfig } from '../types/backend'
+import SettingsCard from './SettingsCard.vue'
+
+const toast = useToast()
+const {
+  sortedBackends,
+  selectedBackend,
+  isLoading,
+  loadBackends,
+  addBackend,
+  updateBackend,
+  deleteBackend,
+  selectBackend,
+  validateUrl,
+} = useBackendSettings()
+
+// Dialog state
+type DialogMode = 'none' | 'add' | 'edit'
+const dialogMode = ref<DialogMode>('none')
+const editingBackend = ref<BackendConfig | null>(null)
+
+// Form state
+const formName = ref('')
+const formUrl = ref('')
+const formError = ref('')
+const formLoading = ref(false)
+
+const dialogTitle = computed(() => {
+  return dialogMode.value === 'add' ? 'Add Backend' : 'Edit Backend'
+})
+
+const dialogVisible = computed({
+  get: () => dialogMode.value !== 'none',
+  set: (value) => {
+    if (!value) {
+      closeDialog()
+    }
+  }
+})
+
+const canDelete = computed(() => {
+  return editingBackend.value && !editingBackend.value.isDefault
+})
+
+onMounted(() => {
+  loadBackends()
+})
+
+function openAddDialog() {
+  dialogMode.value = 'add'
+  editingBackend.value = null
+  formName.value = ''
+  formUrl.value = ''
+  formError.value = ''
+}
+
+function openEditDialog(backend: BackendConfig) {
+  dialogMode.value = 'edit'
+  editingBackend.value = backend
+  formName.value = backend.name
+  formUrl.value = backend.url
+  formError.value = ''
+}
+
+function closeDialog() {
+  dialogMode.value = 'none'
+  editingBackend.value = null
+  formName.value = ''
+  formUrl.value = ''
+  formError.value = ''
+  formLoading.value = false
+}
+
+async function handleSave() {
+  formError.value = ''
+
+  // Validate name
+  if (!formName.value.trim()) {
+    formError.value = 'Name is required'
+    return
+  }
+
+  // Validate URL
+  const urlValidation = validateUrl(formUrl.value)
+  if (!urlValidation.valid) {
+    formError.value = urlValidation.message || 'Invalid URL'
+    return
+  }
+
+  formLoading.value = true
+
+  try {
+    if (dialogMode.value === 'add') {
+      const newBackend = await addBackend(formName.value, formUrl.value)
+      selectBackend(newBackend.id)
+      toast.add({
+        severity: 'success',
+        summary: 'Success',
+        detail: 'Backend added',
+        life: 3000
+      })
+    } else if (editingBackend.value) {
+      await updateBackend(editingBackend.value.id, {
+        name: formName.value,
+        url: formUrl.value,
+      })
+      toast.add({
+        severity: 'success',
+        summary: 'Success',
+        detail: 'Backend updated',
+        life: 3000
+      })
+    }
+    closeDialog()
+  } catch (err) {
+    formError.value = err instanceof Error ? err.message : 'An error occurred'
+  } finally {
+    formLoading.value = false
+  }
+}
+
+async function handleDelete() {
+  if (!editingBackend.value || editingBackend.value.isDefault) {
+    return
+  }
+
+  formLoading.value = true
+
+  try {
+    await deleteBackend(editingBackend.value.id)
+    toast.add({
+      severity: 'success',
+      summary: 'Success',
+      detail: 'Backend deleted',
+      life: 3000
+    })
+    closeDialog()
+  } catch (err) {
+    formError.value = err instanceof Error ? err.message : 'An error occurred'
+  } finally {
+    formLoading.value = false
+  }
+}
+
+function getUrlDisplay(url: string): string {
+  return url || '(Relative Path)'
+}
+</script>
+
+<template>
+  <SettingsCard header="Backend">
+    <!-- Selected backend info -->
+    <div class="settings-item">
+      <div class="item-content">
+        <div class="item-left">
+          <i class="pi pi-server item-icon"></i>
+          <div class="item-text">
+            <span class="item-label">Current Backend</span>
+            <span class="item-description">{{ selectedBackend?.name || 'Not selected' }}</span>
+          </div>
+        </div>
+        <Tag
+          v-if="selectedBackend"
+          severity="success"
+          :value="selectedBackend.isDefault ? 'Default' : 'Custom'"
+        />
+      </div>
+    </div>
+
+    <!-- Backend list -->
+    <button
+      v-for="backend in sortedBackends"
+      :key="backend.id"
+      class="settings-item clickable"
+      :disabled="isLoading"
+      @click="openEditDialog(backend)"
+    >
+      <div class="item-content">
+        <div class="item-left">
+          <i
+            class="pi item-icon"
+            :class="backend.id === selectedBackend?.id ? 'pi-check-circle' : 'pi-circle'"
+          ></i>
+          <div class="item-text">
+            <span class="item-label">{{ backend.name }}</span>
+            <span class="item-description">{{ getUrlDisplay(backend.url) }}</span>
+          </div>
+        </div>
+        <i class="pi pi-chevron-right item-chevron"></i>
+      </div>
+    </button>
+
+    <!-- Add button -->
+    <button
+      class="settings-item clickable"
+      :disabled="isLoading"
+      @click="openAddDialog"
+    >
+      <div class="item-content">
+        <div class="item-left">
+          <i class="pi pi-plus item-icon"></i>
+          <span class="item-label">Add Backend</span>
+        </div>
+        <i class="pi pi-chevron-right item-chevron"></i>
+      </div>
+    </button>
+  </SettingsCard>
+
+  <!-- Add/Edit Dialog -->
+  <Dialog
+    v-model:visible="dialogVisible"
+    modal
+    :header="dialogTitle"
+    :style="{ width: '400px' }"
+    :breakpoints="{ '480px': '90vw' }"
+    :closable="!formLoading"
+  >
+    <div class="dialog-content">
+      <Message v-if="formError" severity="error" :closable="false">
+        {{ formError }}
+      </Message>
+
+      <div class="form-group">
+        <label for="backend-name">Name</label>
+        <InputText
+          id="backend-name"
+          v-model="formName"
+          :disabled="formLoading"
+          placeholder="e.g., Home Server"
+          class="form-input"
+        />
+      </div>
+
+      <div class="form-group">
+        <label for="backend-url">URL</label>
+        <InputText
+          id="backend-url"
+          v-model="formUrl"
+          :disabled="formLoading"
+          placeholder="e.g., http://192.168.1.100:3000"
+          class="form-input"
+        />
+        <small class="form-hint">Leave empty for relative path (same origin)</small>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="dialog-footer">
+        <div class="footer-left">
+          <Button
+            v-if="dialogMode === 'edit' && canDelete"
+            label="Delete"
+            icon="pi pi-trash"
+            severity="danger"
+            text
+            :loading="formLoading"
+            @click="handleDelete"
+          />
+        </div>
+        <div class="footer-right">
+          <Button
+            label="Cancel"
+            text
+            :disabled="formLoading"
+            @click="closeDialog"
+          />
+          <Button
+            label="Save"
+            icon="pi pi-check"
+            :loading="formLoading"
+            :disabled="!formName.trim()"
+            @click="handleSave"
+          />
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<style scoped>
+.dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--p-text-color);
+}
+
+.form-input {
+  width: 100%;
+}
+
+.form-hint {
+  font-size: 0.8125rem;
+  color: var(--p-text-muted-color);
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.footer-left {
+  flex-shrink: 0;
+}
+
+.footer-right {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/frontend/src/composables/useApi.ts
+++ b/frontend/src/composables/useApi.ts
@@ -1,14 +1,19 @@
 import { ref, computed } from "vue";
 import type { SearchResponse, SearchHit, BatchTagResponse, StatsResponse } from "../types/api";
+import { useBackendSettings } from "./useBackendSettings";
 
-const API_BASE = import.meta.env.VITE_API_BASE || "";
+const { selectedUrl } = useBackendSettings();
+
+function getApiBase(): string {
+  return selectedUrl.value || import.meta.env.VITE_API_BASE || "";
+}
 
 // Batch tagging API functions
 export async function addTagsToImages(
   imageIds: string[],
   tags: string[]
 ): Promise<BatchTagResponse> {
-  const response = await fetch(`${API_BASE}/api/images/tags`, {
+  const response = await fetch(`${getApiBase()}/api/images/tags`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ imageIds, tags }),
@@ -27,7 +32,7 @@ export async function removeTagFromImage(
   tagId: string
 ): Promise<void> {
   const response = await fetch(
-    `${API_BASE}/api/images/${imageId}/tags/${tagId}`,
+    `${getApiBase()}/api/images/${imageId}/tags/${tagId}`,
     { method: "DELETE" }
   );
 
@@ -38,7 +43,7 @@ export async function removeTagFromImage(
 }
 
 export async function deleteImage(imageId: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/api/images/${imageId}`, {
+  const response = await fetch(`${getApiBase()}/api/images/${imageId}`, {
     method: "DELETE",
   });
 
@@ -50,7 +55,7 @@ export async function deleteImage(imageId: string): Promise<void> {
 
 // Stats API function
 export async function fetchStats(): Promise<StatsResponse> {
-  const response = await fetch(`${API_BASE}/api/stats`);
+  const response = await fetch(`${getApiBase()}/api/stats`);
 
   if (!response.ok) {
     throw new Error("Failed to fetch stats");
@@ -92,7 +97,7 @@ export function useInfiniteSearch() {
       params.set("offset", "0");
       params.set("mode", searchMode.value);
 
-      const response = await fetch(`${API_BASE}/api/search?${params}`);
+      const response = await fetch(`${getApiBase()}/api/search?${params}`);
       if (!response.ok) {
         throw new Error("Search failed");
       }
@@ -125,7 +130,7 @@ export function useInfiniteSearch() {
       params.set("offset", images.value.length.toString());
       params.set("mode", searchMode.value);
 
-      const response = await fetch(`${API_BASE}/api/search?${params}`);
+      const response = await fetch(`${getApiBase()}/api/search?${params}`);
       if (!response.ok) {
         throw new Error("Failed to load more");
       }

--- a/frontend/src/composables/useBackendSettings.ts
+++ b/frontend/src/composables/useBackendSettings.ts
@@ -1,0 +1,269 @@
+import { ref, computed, watch } from "vue";
+import type { BackendConfig } from "../types/backend";
+
+const DB_NAME = "soeji-settings";
+const DB_VERSION = 1;
+const STORE_NAME = "backends";
+const SELECTED_KEY = "soeji-backend-selected";
+
+const DEFAULT_BACKEND: BackendConfig = {
+  id: "local",
+  name: "Local",
+  url: "",
+  isDefault: true,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+};
+
+// Singleton state
+const backends = ref<BackendConfig[]>([]);
+const selectedId = ref<string | null>(null);
+const isLoading = ref(false);
+const error = ref<string | null>(null);
+const isInitialized = ref(false);
+
+let dbInstance: IDBDatabase | null = null;
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (dbInstance) {
+      resolve(dbInstance);
+      return;
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      reject(new Error("Failed to open database"));
+    };
+
+    request.onsuccess = () => {
+      dbInstance = request.result;
+      resolve(dbInstance);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+  });
+}
+
+function getAllBackends(db: IDBDatabase): Promise<BackendConfig[]> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      resolve(request.result || []);
+    };
+
+    request.onerror = () => {
+      reject(new Error("Failed to get backends"));
+    };
+  });
+}
+
+function putBackend(db: IDBDatabase, backend: BackendConfig): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(backend);
+
+    request.onsuccess = () => {
+      resolve();
+    };
+
+    request.onerror = () => {
+      reject(new Error("Failed to save backend"));
+    };
+  });
+}
+
+function removeBackend(db: IDBDatabase, id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.delete(id);
+
+    request.onsuccess = () => {
+      resolve();
+    };
+
+    request.onerror = () => {
+      reject(new Error("Failed to delete backend"));
+    };
+  });
+}
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export function useBackendSettings() {
+  const selectedBackend = computed(() =>
+    backends.value.find((b) => b.id === selectedId.value) || backends.value[0] || null
+  );
+
+  const selectedUrl = computed(() => selectedBackend.value?.url || "");
+
+  const sortedBackends = computed(() =>
+    [...backends.value].sort((a, b) => {
+      // Default backend first, then sort by name
+      if (a.isDefault) return -1;
+      if (b.isDefault) return 1;
+      return a.name.localeCompare(b.name);
+    })
+  );
+
+  async function loadBackends(): Promise<void> {
+    if (isInitialized.value) return;
+
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      const db = await openDatabase();
+      const stored = await getAllBackends(db);
+
+      if (stored.length === 0) {
+        // Create default backend
+        await putBackend(db, DEFAULT_BACKEND);
+        backends.value = [DEFAULT_BACKEND];
+      } else {
+        backends.value = stored;
+      }
+
+      // Restore selected ID from localStorage
+      const savedSelectedId = localStorage.getItem(SELECTED_KEY);
+      if (savedSelectedId && backends.value.some((b) => b.id === savedSelectedId)) {
+        selectedId.value = savedSelectedId;
+      } else {
+        // Select default backend
+        const defaultBackend = backends.value.find((b) => b.isDefault);
+        selectedId.value = defaultBackend?.id || backends.value[0]?.id || null;
+      }
+
+      isInitialized.value = true;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "Failed to load backends";
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  async function addBackend(name: string, url: string): Promise<BackendConfig> {
+    const db = await openDatabase();
+    const newBackend: BackendConfig = {
+      id: generateId(),
+      name: name.trim(),
+      url: url.trim(),
+      isDefault: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    await putBackend(db, newBackend);
+    backends.value = [...backends.value, newBackend];
+
+    return newBackend;
+  }
+
+  async function updateBackend(
+    id: string,
+    updates: Partial<Pick<BackendConfig, "name" | "url">>
+  ): Promise<void> {
+    const backend = backends.value.find((b) => b.id === id);
+    if (!backend) {
+      throw new Error("Backend not found");
+    }
+
+    const db = await openDatabase();
+    const updatedBackend: BackendConfig = {
+      ...backend,
+      ...(updates.name !== undefined && { name: updates.name.trim() }),
+      ...(updates.url !== undefined && { url: updates.url.trim() }),
+      updatedAt: Date.now(),
+    };
+
+    await putBackend(db, updatedBackend);
+    backends.value = backends.value.map((b) =>
+      b.id === id ? updatedBackend : b
+    );
+  }
+
+  async function deleteBackend(id: string): Promise<void> {
+    const backend = backends.value.find((b) => b.id === id);
+    if (!backend) {
+      throw new Error("Backend not found");
+    }
+
+    if (backend.isDefault) {
+      throw new Error("Cannot delete default backend");
+    }
+
+    const db = await openDatabase();
+    await removeBackend(db, id);
+    backends.value = backends.value.filter((b) => b.id !== id);
+
+    // If deleted backend was selected, switch to default
+    if (selectedId.value === id) {
+      const defaultBackend = backends.value.find((b) => b.isDefault);
+      selectedId.value = defaultBackend?.id || backends.value[0]?.id || null;
+    }
+  }
+
+  function selectBackend(id: string): void {
+    if (backends.value.some((b) => b.id === id)) {
+      selectedId.value = id;
+    }
+  }
+
+  function validateUrl(url: string): { valid: boolean; message?: string } {
+    const trimmed = url.trim();
+
+    // Empty URL is allowed (relative path)
+    if (!trimmed) {
+      return { valid: true };
+    }
+
+    try {
+      const parsed = new URL(trimmed);
+      if (!["http:", "https:"].includes(parsed.protocol)) {
+        return { valid: false, message: "URL must use http or https protocol" };
+      }
+      return { valid: true };
+    } catch {
+      return { valid: false, message: "Invalid URL format" };
+    }
+  }
+
+  // Persist selected ID to localStorage
+  watch(selectedId, (newId) => {
+    if (newId) {
+      localStorage.setItem(SELECTED_KEY, newId);
+    } else {
+      localStorage.removeItem(SELECTED_KEY);
+    }
+  });
+
+  return {
+    backends,
+    selectedId,
+    selectedBackend,
+    selectedUrl,
+    sortedBackends,
+    isLoading,
+    error,
+    isInitialized,
+    loadBackends,
+    addBackend,
+    updateBackend,
+    deleteBackend,
+    selectBackend,
+    validateUrl,
+  };
+}

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
+import BackendSettings from '../components/BackendSettings.vue'
 import PinSettings from '../components/PinSettings.vue'
 import VersionInfo from '../components/VersionInfo.vue'
 
@@ -28,6 +29,7 @@ function goBack() {
       </header>
 
       <div class="settings-content">
+        <BackendSettings />
         <PinSettings />
         <VersionInfo />
       </div>

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -1,0 +1,8 @@
+export interface BackendConfig {
+  id: string;
+  name: string;
+  url: string;
+  isDefault: boolean;
+  createdAt: number;
+  updatedAt: number;
+}


### PR DESCRIPTION
- フロントエンド: 設定画面でバックエンドURLを追加・編集・削除可能に
- フロントエンド: ヘッダーにDropdownで切り替えUIを追加
- フロントエンド: IndexedDBでバックエンド設定を永続化
- バックエンド: CORS_ALLOWED_ORIGINS環境変数で許可オリジンを設定可能に