### PR TITLE
フルスクリーンモードの切り替え機能を追加

### DIFF
--- a/frontend/src/components/FullscreenSettings.vue
+++ b/frontend/src/components/FullscreenSettings.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import SelectButton from 'primevue/selectbutton'
+import { useFullscreenSettings, type FullscreenMode } from '../composables/useFullscreenSettings'
+import SettingsCard from './SettingsCard.vue'
+
+const { fullscreenMode, setFullscreenMode } = useFullscreenSettings()
+
+const fullscreenModeOptions = [
+  { label: 'Monitor', value: 'api' as FullscreenMode },
+  { label: 'Browser', value: 'css' as FullscreenMode },
+]
+
+function handleChange(value: FullscreenMode) {
+  setFullscreenMode(value)
+}
+</script>
+
+<template>
+  <SettingsCard header="Display">
+    <div class="settings-item">
+      <div class="item-content">
+        <div class="item-left">
+          <i class="pi pi-expand item-icon"></i>
+          <div class="item-text">
+            <span class="item-label">Default Fullscreen Mode</span>
+            <span class="item-description">
+              Hold Shift while clicking to use the alternate mode
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="settings-item">
+      <div class="item-content fullscreen-select-content">
+        <SelectButton
+          :modelValue="fullscreenMode"
+          :options="fullscreenModeOptions"
+          optionLabel="label"
+          optionValue="value"
+          class="fullscreen-select-button"
+          @update:modelValue="handleChange"
+        />
+      </div>
+    </div>
+  </SettingsCard>
+</template>
+
+<style scoped>
+.fullscreen-select-content {
+  justify-content: center;
+}
+
+.fullscreen-select-button {
+  width: 100%;
+  display: flex;
+}
+
+.fullscreen-select-button :deep(.p-togglebutton) {
+  flex: 1;
+}
+</style>

--- a/frontend/src/composables/useFullscreenSettings.ts
+++ b/frontend/src/composables/useFullscreenSettings.ts
@@ -1,0 +1,33 @@
+import { ref, computed } from 'vue'
+
+const STORAGE_KEY_FULLSCREEN_MODE = 'soeji-fullscreen-mode'
+
+/**
+ * Fullscreen modes:
+ * - 'api': Use browser Fullscreen API (true fullscreen, hides browser UI)
+ * - 'css': CSS-only fullscreen (fills viewport but browser UI remains visible)
+ */
+export type FullscreenMode = 'api' | 'css'
+
+// Default: API fullscreen (current behavior)
+const DEFAULT_FULLSCREEN_MODE: FullscreenMode = 'api'
+
+// Reactive state (synced with localStorage)
+const fullscreenMode = ref<FullscreenMode>(
+  (localStorage.getItem(STORAGE_KEY_FULLSCREEN_MODE) as FullscreenMode) || DEFAULT_FULLSCREEN_MODE
+)
+
+export function useFullscreenSettings() {
+  /**
+   * Set fullscreen mode preference
+   */
+  function setFullscreenMode(mode: FullscreenMode): void {
+    localStorage.setItem(STORAGE_KEY_FULLSCREEN_MODE, mode)
+    fullscreenMode.value = mode
+  }
+
+  return {
+    fullscreenMode: computed(() => fullscreenMode.value),
+    setFullscreenMode,
+  }
+}

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -2,6 +2,7 @@
 import { useRouter } from 'vue-router'
 import Button from 'primevue/button'
 import PinSettings from '../components/PinSettings.vue'
+import FullscreenSettings from '../components/FullscreenSettings.vue'
 import VersionInfo from '../components/VersionInfo.vue'
 
 const router = useRouter()
@@ -29,6 +30,7 @@ function goBack() {
 
       <div class="settings-content">
         <PinSettings />
+        <FullscreenSettings />
         <VersionInfo />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- フルスクリーンボタンの挙動を2つのモードで切り替え可能に
  - **Monitor**: Fullscreen API を使用した真のフルスクリーン（ブラウザUIを非表示）
  - **Browser**: CSS のみでブラウザウィンドウ内フルスクリーン（従来の f5a0cb 以前の挙動）
- デフォルトは Monitor モード
- Shift キーを押しながらボタンをクリックすると反対のモードで開く
- 設定画面からデフォルトモードを変更可能

## Test plan
- [ ] ライトボックスでフルスクリーンボタンをクリックし、Monitor モード（Fullscreen API）で動作することを確認
- [ ] Shift+クリックで Browser モード（CSS のみ）に切り替わることを確認
- [ ] 設定画面でデフォルトモードを Browser に変更できることを確認
- [ ] 設定変更後、通常クリックで Browser モード、Shift+クリックで Monitor モードになることを確認
- [ ] 設定がリロード後も保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)